### PR TITLE
Fix Duration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 
-
 jaeger-kusto
 
 .idea/
@@ -22,3 +21,6 @@ jaeger-kusto
 jaeger-kusto-config.json
 kompose
 build/server/helm/values.yaml
+
+.claude
+CLAUDE.md

--- a/store/reader.go
+++ b/store/reader.go
@@ -217,12 +217,12 @@ func (r *kustoSpanReader) FindTraceIDs(ctx context.Context, query *spanstore.Tra
 
 	if query.DurationMin != 0 {
 		kustoStmt = kustoStmt.AddLiteral(` | where Duration > ParamDurationMin`)
-		kustoParameters = kustoParameters.AddTimespan("ParamDurationMin", query.DurationMin)
+		kustoParameters = kustoParameters.AddLong("ParamDurationMin", query.DurationMin.Microseconds())
 	}
 
 	if query.DurationMax != 0 {
 		kustoStmt = kustoStmt.AddLiteral(` | where Duration < ParamDurationMax`)
-		kustoParameters = kustoParameters.AddTimespan("ParamDurationMax", query.DurationMax)
+		kustoParameters = kustoParameters.AddLong("ParamDurationMax", query.DurationMax.Microseconds())
 	}
 
 	kustoStmt = kustoStmt.AddLiteral("| summarize by TraceID")
@@ -299,12 +299,12 @@ func (r *kustoSpanReader) FindTraces(ctx context.Context, query *spanstore.Trace
 
 	if query.DurationMin != 0 {
 		kustoStmt = kustoStmt.AddLiteral(` | where Duration > ParamDurationMin`)
-		kustoParameters = kustoParameters.AddTimespan("ParamDurationMin", query.DurationMin)
+		kustoParameters = kustoParameters.AddLong("ParamDurationMin", query.DurationMin.Microseconds())
 	}
 
 	if query.DurationMax != 0 {
 		kustoStmt = kustoStmt.AddLiteral(` | where Duration < ParamDurationMax`)
-		kustoParameters = kustoParameters.AddTimespan("ParamDurationMax", query.DurationMax)
+		kustoParameters = kustoParameters.AddLong("ParamDurationMax", query.DurationMax.Microseconds())
 	}
 
 	kustoStmt = kustoStmt.AddLiteral(" | summarize by TraceID")

--- a/store/reader.go
+++ b/store/reader.go
@@ -222,7 +222,7 @@ func (r *kustoSpanReader) FindTraceIDs(ctx context.Context, query *spanstore.Tra
 	}
 
 	if query.DurationMax != 0 {
-		kustoStmt = kustoStmt.AddLiteral(` | where Duration > ParamDurationMax`)
+		kustoStmt = kustoStmt.AddLiteral(` | where Duration < ParamDurationMax`)
 		kustoParameters = kustoParameters.AddTimespan("ParamDurationMax", query.DurationMax)
 	}
 
@@ -304,7 +304,7 @@ func (r *kustoSpanReader) FindTraces(ctx context.Context, query *spanstore.Trace
 	}
 
 	if query.DurationMax != 0 {
-		kustoStmt = kustoStmt.AddLiteral(` | where Duration > ParamDurationMax`)
+		kustoStmt = kustoStmt.AddLiteral(` | where Duration < ParamDurationMax`)
 		kustoParameters = kustoParameters.AddTimespan("ParamDurationMax", query.DurationMax)
 	}
 
@@ -314,7 +314,7 @@ func (r *kustoSpanReader) FindTraces(ctx context.Context, query *spanstore.Trace
 	kustoParameters = kustoParameters.AddInt("ParamNumTraces", int32(query.NumTraces))
 
 	kustoStmt = kustoStmt.AddLiteral(`); `).AddTable(r.tableName).AddLiteral(getTracesBaseQuery)
-	
+
 	kustoStmt = kustoStmt.AddLiteral(` | where StartTime > ParamStartTimeMin`)
 	kustoParameters = kustoParameters.AddDateTime("ParamStartTimeMin", query.StartTimeMin)
 

--- a/store/reader.go
+++ b/store/reader.go
@@ -30,7 +30,6 @@ type kustoReaderClient interface {
 	Query(ctx context.Context, db string, query kusto.Statement, options ...kusto.QueryOption) (*kusto.RowIterator, error)
 }
 
-var queryMap = map[string]string{}
 
 func newKustoSpanReader(factory *kustoFactory, logger hclog.Logger, defaultReadOptions []kusto.QueryOption) (*kustoSpanReader, error) {
 	return &kustoSpanReader{

--- a/store/reader.go
+++ b/store/reader.go
@@ -232,6 +232,7 @@ func (r *kustoSpanReader) FindTraceIDs(ctx context.Context, query *spanstore.Tra
 		kustoParameters = kustoParameters.AddInt("ParamNumTraces", int32(query.NumTraces))
 	}
 
+	r.logger.Debug("FindTraceIDs query: %s", kustoStmt.String())
 	clientRequestId := GetClientId()
 	iter, err := r.client.Query(ctx, r.database, kustoStmt, append(r.defaultReadOptions, kusto.ClientRequestID(clientRequestId), kusto.QueryParameters(kustoParameters))...)
 	if err != nil {
@@ -322,7 +323,7 @@ func (r *kustoSpanReader) FindTraces(ctx context.Context, query *spanstore.Trace
 
 	kustoStmt = kustoStmt.AddLiteral(` | where TraceID in (TraceIDs) | project-rename Tags=TraceAttributes,Logs=Events,ProcessTags=ResourceAttributes|extend References=iff(isempty(ParentID),todynamic("[]"),pack_array(bag_pack("refType","CHILD_OF","traceID",TraceID,"spanID",ParentID)))`)
 
-	r.logger.Debug(kustoStmt.String())
+	r.logger.Debug("FindTraces query: %s", kustoStmt.String())
 	clientRequestId := GetClientId()
 	iter, err := r.client.Query(ctx, r.database, kustoStmt, append(r.defaultReadOptions, kusto.ClientRequestID(clientRequestId), kusto.QueryParameters(kustoParameters))...)
 	if err != nil {

--- a/test/store/reader_test.go
+++ b/test/store/reader_test.go
@@ -271,3 +271,137 @@ func TestFindTracesWithBothDurationMinAndMax(t *testing.T) {
 		"FindTraces should not generate incorrect duration max condition")
 }
 
+func TestFindTraceIDsWithDurationMax(t *testing.T) {
+	query := &spanstore.TraceQueryParameters{
+		ServiceName:  "test-service",
+		StartTimeMin: time.Date(2023, time.January, 29, 06, 0, 0, 0, time.UTC),
+		StartTimeMax: time.Date(2023, time.January, 30, 23, 0, 0, 0, time.UTC),
+		DurationMax:  time.Millisecond * 500,
+		NumTraces:    10,
+	}
+
+	kustoConfig := &config.KustoConfig{
+		ClientID:       "test-client-id",
+		ClientSecret:   "test-client-secret",
+		TenantID:       "test-tenant-id",
+		Endpoint:       "https://test.kusto.windows.net",
+		Database:       "test-db",
+		TraceTableName: "OTELTraces",
+	}
+
+	var buf bytes.Buffer
+	logger := hclog.New(&hclog.LoggerOptions{
+		Output: &buf,
+		Level:  hclog.Debug,
+	})
+
+	kustoStore, err := store.NewStore(testPluginConfig, kustoConfig, logger)
+	if err != nil {
+		t.Skipf("Skipping test due to store creation error: %v", err)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, _ = kustoStore.SpanReader().FindTraceIDs(ctx, query)
+
+	output := buf.String()
+
+	assert.Contains(t, output, "| where Duration < ParamDurationMax", 
+		"FindTraceIDs should generate correct duration max condition with '<' operator")
+
+	assert.NotContains(t, output, "| where Duration > ParamDurationMax", 
+		"FindTraceIDs should not generate incorrect duration max condition with '>' operator")
+}
+
+func TestFindTraceIDsWithDurationMin(t *testing.T) {
+	query := &spanstore.TraceQueryParameters{
+		ServiceName:  "test-service",
+		StartTimeMin: time.Date(2023, time.January, 29, 06, 0, 0, 0, time.UTC),
+		StartTimeMax: time.Date(2023, time.January, 30, 23, 0, 0, 0, time.UTC),
+		DurationMin:  time.Millisecond * 100,
+		NumTraces:    10,
+	}
+
+	kustoConfig := &config.KustoConfig{
+		ClientID:       "test-client-id",
+		ClientSecret:   "test-client-secret",
+		TenantID:       "test-tenant-id",
+		Endpoint:       "https://test.kusto.windows.net",
+		Database:       "test-db",
+		TraceTableName: "OTELTraces",
+	}
+
+	var buf bytes.Buffer
+	logger := hclog.New(&hclog.LoggerOptions{
+		Output: &buf,
+		Level:  hclog.Debug,
+	})
+
+	kustoStore, err := store.NewStore(testPluginConfig, kustoConfig, logger)
+	if err != nil {
+		t.Skipf("Skipping test due to store creation error: %v", err)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, _ = kustoStore.SpanReader().FindTraceIDs(ctx, query)
+
+	output := buf.String()
+
+	assert.Contains(t, output, "| where Duration > ParamDurationMin", 
+		"FindTraceIDs should generate correct duration min condition with '>' operator")
+}
+
+func TestFindTraceIDsWithBothDurationMinAndMax(t *testing.T) {
+	query := &spanstore.TraceQueryParameters{
+		ServiceName:  "test-service",
+		StartTimeMin: time.Date(2023, time.January, 29, 06, 0, 0, 0, time.UTC),
+		StartTimeMax: time.Date(2023, time.January, 30, 23, 0, 0, 0, time.UTC),
+		DurationMin:  time.Millisecond * 100,
+		DurationMax:  time.Millisecond * 500,
+		NumTraces:    10,
+	}
+
+	kustoConfig := &config.KustoConfig{
+		ClientID:       "test-client-id",
+		ClientSecret:   "test-client-secret",
+		TenantID:       "test-tenant-id",
+		Endpoint:       "https://test.kusto.windows.net",
+		Database:       "test-db",
+		TraceTableName: "OTELTraces",
+	}
+
+	var buf bytes.Buffer
+	logger := hclog.New(&hclog.LoggerOptions{
+		Output: &buf,
+		Level:  hclog.Debug,
+	})
+
+	kustoStore, err := store.NewStore(testPluginConfig, kustoConfig, logger)
+	if err != nil {
+		t.Skipf("Skipping test due to store creation error: %v", err)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, _ = kustoStore.SpanReader().FindTraceIDs(ctx, query)
+
+	output := buf.String()
+
+	assert.Contains(t, output, "| where Duration > ParamDurationMin", 
+		"FindTraceIDs should generate correct duration min condition with '>' operator")
+	assert.Contains(t, output, "| where Duration < ParamDurationMax", 
+		"FindTraceIDs should generate correct duration max condition with '<' operator")
+		
+	assert.NotContains(t, output, "| where Duration < ParamDurationMin", 
+		"FindTraceIDs should not generate incorrect duration min condition")
+	assert.NotContains(t, output, "| where Duration > ParamDurationMax", 
+		"FindTraceIDs should not generate incorrect duration max condition")
+}
+


### PR DESCRIPTION
Hi!
Faced with this error:
`
HTTP Error: stream error: rpc error: code = Unknown desc = Op(OpQuery): Kind(KHTTPError): error from Kusto endpoint, With query: let TraceIDs = (Traces | extend ProcessServiceName=tostring(ResourceAttributes.['service.name']),Duration=datetime_diff('microsecond',EndTime,StartTime) | where ProcessServiceName == ParamProcessServiceName | where StartTime > ParamStartTimeMin | where StartTime < ParamStartTimeMax | where Duration > ParamDurationMin | summarize by TraceID | sample ParamNumTraces); Traces | extend ProcessServiceName=tostring(ResourceAttributes.['service.name']),Duration=datetime_diff('microsecond',EndTime,StartTime) | where StartTime > ParamStartTimeMin | where StartTime < ParamStartTimeMax | where TraceID in (TraceIDs) | project-rename Tags=TraceAttributes,Logs=Events,ProcessTags=ResourceAttributes|extend References=iff(isempty(ParentID),todynamic("[]"),pack_array(bag_pack("refType","CHILD_OF","traceID",TraceID,"spanID",ParentID)))(400 BadRequest): { "error": { "code": "General_BadRequest", "message": "Request is invalid and cannot be executed.", "@type": "Kusto.Data.Exceptions.KustoBadRequestException", "@message": "Request is invalid and cannot be processed: Semantic error: SEM0064: Cannot compare values of types long and timespan. Try adding explicit casts"...`