### PR TITLE
*Add some fixes on the helm chart

### DIFF
--- a/build/server/docker-compose.yml
+++ b/build/server/docker-compose.yml
@@ -18,21 +18,18 @@ services:
       - "../../jaeger-kusto-config.json:/config/jaeger-kusto-config.json"
       - "./jaeger-kusto-plugin-config.json:/config/jaeger-kusto-plugin-config.json"
   jaeger:
-    image: jaegertracing/all-in-one:1.76.0
+    image: jaegertracing/jaeger:2.16.0
     ports:
-      - "5775:5775/udp"
-      - "6831:6831/udp"
-      - "6832:6832/udp"
-      - "5778:5778"
       - "16686:16686"
-      - "14268:14268"
-      - "14250:14250"
-    environment:
-      "SPAN_STORAGE_TYPE": "grpc"
+      - "16685:16685"
+      - "4317:4317"
+      - "4318:4318"
+      - "13133:13133"
+    volumes:
+      - "../../config/jaeger-v2-config.yaml:/etc/jaeger/jaeger-v2-config.yaml"
+      - "../../config/jaeger-ui.json:/etc/jaeger/jaeger-ui.json"
     command:
-      - "--grpc-storage.server=plugin:8989"
-      - "--grpc-storage.connection-timeout=60s"
-      - "--grpc-storage.tls.enabled=false"
+      - "--config=/etc/jaeger/jaeger-v2-config.yaml"
   # hotrod:
   #   image: jaegertracing/example-hotrod:latest
   #   ports:

--- a/build/server/helm/templates/jaeger-deployment.yaml
+++ b/build/server/helm/templates/jaeger-deployment.yaml
@@ -1,62 +1,76 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  namespace: {{ .Release.Namespace }}
   labels:
     io.service.name: kusto-jaeger
   name: jaeger
 spec:
-  replicas: 2
+  replicas: {{ .Values.jaeger.replicas | default 2 }}
   selector:
     matchLabels:
       io.service.name: kusto-jaeger
   template:
     metadata:
-      annotations:
-        service.version: 1.1.0-Preview
       labels:
         io.kompose.network/server-default: "true"
         io.service.name: kusto-jaeger
     spec:
       containers:
-        - args:
-            - --grpc-storage.server=kusto-jaeger-plugin:8989
-            - --grpc-storage.connection-timeout=60s
-            - --grpc-storage.tls.enabled=false
-            - --query.base-path=/tracing
-            {{- if .Values.metrics.enabled }}
-            - --prometheus.server-url={{ .Values.metrics.prometheusServerUrl | default "http://kusto-jaeger-plugin:9090" }}
-            - --prometheus.query.normalize-calls=true
-            - --prometheus.query.normalize-duration=true
-            {{- end }}
-          env:
-            - name: SPAN_STORAGE_TYPE
-              value: grpc
-            {{- if .Values.metrics.enabled }}
-            - name: METRICS_STORAGE_TYPE
-              value: prometheus
-            {{- end }}
-          image: jaegertracing/all-in-one:1.76.0
-          name: jaeger
+        - name: jaeger
+          image: {{ .Values.jaeger.image }}:{{ .Values.jaeger.imageTag }}
+          args:
+            - --config=/etc/jaeger/jaeger-v2-config.yaml
           ports:
-            - containerPort: 16686
-              hostPort: 16686
+            - name: query-http
+              containerPort: 16686
               protocol: TCP
-            - containerPort: 16687
-              hostPort: 16687
+            - name: query-grpc
+              containerPort: 16685
               protocol: TCP
-          {{- if .Values.metrics.enabled }}
+            - name: otlp-grpc
+              containerPort: 4317
+              protocol: TCP
+            - name: otlp-http
+              containerPort: 4318
+              protocol: TCP
+            - name: health
+              containerPort: 13133
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133
+            initialDelaySeconds: 15
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133
+            initialDelaySeconds: 5
+            periodSeconds: 10
           volumeMounts:
+            - name: jaeger-v2-config
+              mountPath: /etc/jaeger/jaeger-v2-config.yaml
+              subPath: jaeger-v2-config.yaml
+            {{- if .Values.metrics.enabled }}
             - name: jaeger-ui-config
               mountPath: /etc/jaeger/jaeger-ui.json
               subPath: jaeger-ui.json
-          {{- end }}
+            {{- end }}
       restartPolicy: Always
-      {{- if .Values.metrics.enabled }}
       volumes:
+        - name: jaeger-v2-config
+          configMap:
+            name: jaeger-v2-config
+            items:
+              - key: jaeger-v2-config.yaml
+                path: jaeger-v2-config.yaml
+        {{- if .Values.metrics.enabled }}
         - name: jaeger-ui-config
           configMap:
             name: jaeger-ui-config
             items:
               - key: jaeger-ui.json
                 path: jaeger-ui.json
-      {{- end }}
+        {{- end }}

--- a/build/server/helm/templates/jaeger-service.yaml
+++ b/build/server/helm/templates/jaeger-service.yaml
@@ -1,35 +1,26 @@
 apiVersion: v1
 kind: Service
 metadata:
-
+  namespace: {{ .Release.Namespace }}
   labels:
     io.service.name: kusto-jaeger
   name: jaeger
 spec:
   ports:
-    - name: "5775"
-      port: 5775
-      protocol: UDP
-      targetPort: 5775
-    - name: "6831"
-      port: 6831
-      protocol: UDP
-      targetPort: 6831
-    - name: "6832"
-      port: 6832
-      protocol: UDP
-      targetPort: 6832
-    - name: "5778"
-      port: 5778
-      targetPort: 5778
-    - name: "16686"
+    - name: "query-http"
       port: 16686
       targetPort: 16686
-    - name: "14268"
-      port: 14268
-      targetPort: 14268
-    - name: "14250"
-      port: 14250
-      targetPort: 14250
+    - name: "query-grpc"
+      port: 16685
+      targetPort: 16685
+    - name: "otlp-grpc"
+      port: 4317
+      targetPort: 4317
+    - name: "otlp-http"
+      port: 4318
+      targetPort: 4318
+    - name: "health"
+      port: 13133
+      targetPort: 13133
   selector:
     io.service.name: kusto-jaeger

--- a/build/server/helm/templates/jaeger-v2-configmap.yaml
+++ b/build/server/helm/templates/jaeger-v2-configmap.yaml
@@ -1,0 +1,61 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: {{ .Release.Namespace }}
+  labels:
+    io.service.name: kusto-jaeger
+  name: jaeger-v2-config
+data:
+  jaeger-v2-config.yaml: |
+    extensions:
+      healthcheckv2:
+        endpoint: "0.0.0.0:13133"
+
+      jaeger_storage:
+        backends:
+          kusto_traces:
+            grpc:
+              endpoint: "kusto-jaeger-plugin:8989"
+              timeout: 30s
+              tls:
+                insecure: true
+
+        {{- if .Values.metrics.enabled }}
+        metric_backends:
+          kusto_metrics:
+            prometheus:
+              endpoint: {{ .Values.metrics.prometheusServerUrl | default "http://kusto-jaeger-plugin:9090" | quote }}
+              normalize_calls: true
+              normalize_duration: true
+        {{- end }}
+
+      jaeger_query:
+        storage:
+          traces: kusto_traces
+          {{- if .Values.metrics.enabled }}
+          metrics: kusto_metrics
+          {{- end }}
+        base_path: {{ .Values.jaeger.queryBasePath | default "/tracing" }}
+        {{- if .Values.metrics.enabled }}
+        ui:
+          config_file: /etc/jaeger/jaeger-ui.json
+        {{- end }}
+
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: "0.0.0.0:4317"
+          http:
+            endpoint: "0.0.0.0:4318"
+
+    exporters:
+      jaeger_storage_exporter:
+        trace_storage: kusto_traces
+
+    service:
+      extensions: [healthcheckv2, jaeger_storage, jaeger_query]
+      pipelines:
+        traces:
+          receivers: [otlp]
+          exporters: [jaeger_storage_exporter]

--- a/build/server/helm/templates/kusto-plugin-service.yaml
+++ b/build/server/helm/templates/kusto-plugin-service.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: {{ .Release.Namespace }}
   labels:
     io.service.name: kusto-jaeger-plugin
   name: kusto-jaeger-plugin

--- a/config/jaeger-v2-config.yaml
+++ b/config/jaeger-v2-config.yaml
@@ -6,13 +6,19 @@
 #
 # Start the jaeger-kusto plugin with metricsEnabled=true first,
 # then start Jaeger V2 with this config.
+#
+# For docker-compose: endpoints use service name "plugin"
+# For Kubernetes: override endpoints via Helm values (jaeger-v2-configmap.yaml)
 
 extensions:
+  healthcheckv2:
+    endpoint: "0.0.0.0:13133"
+
   jaeger_storage:
     backends:
       kusto_traces:
         grpc:
-          endpoint: "jaeger-kusto:8989"
+          endpoint: "plugin:8989"
           timeout: 30s
           tls:
             insecure: true
@@ -20,12 +26,13 @@ extensions:
     metric_backends:
       kusto_metrics:
         prometheus:
-          endpoint: "http://jaeger-kusto:9090"
+          endpoint: "http://plugin:9090"
 
   jaeger_query:
     storage:
       traces: kusto_traces
       metrics: kusto_metrics
+    base_path: /tracing
     ui:
       config_file: /etc/jaeger/jaeger-ui.json
 
@@ -42,7 +49,7 @@ exporters:
     trace_storage: kusto_traces
 
 service:
-  extensions: [jaeger_storage, jaeger_query]
+  extensions: [healthcheckv2, jaeger_storage, jaeger_query]
   pipelines:
     traces:
       receivers: [otlp]


### PR DESCRIPTION
This pull request upgrades the Jaeger tracing deployment to use Jaeger V2, modernizes its configuration, and improves Kubernetes and Docker Compose integration. The changes introduce a new config file structure, update service ports to match the new Jaeger V2 endpoints, and enhance health checking and metrics support. The deployment is now more configurable via Helm values and better aligned with best practices for both local and Kubernetes environments.

**Jaeger V2 upgrade and configuration:**

* Upgraded the Jaeger image from `jaegertracing/all-in-one:1.76.0` to `jaegertracing/jaeger:2.16.0` in Docker Compose and Helm, and switched to using a new configuration file (`jaeger-v2-config.yaml`) for Jaeger V2. [[1]](diffhunk://#diff-dc4762061a8de4483fe4f8025b5a08c5e74d6dd02f80fdc721ace955026ebd1cL21-R32) [[2]](diffhunk://#diff-21a24b220f7443d0c1516e807148e96e0c5b392eaa2957316acb5b56d2e1fc5fR4-R69)
* Added a new Jaeger V2 config map (`jaeger-v2-configmap.yaml`) for Kubernetes, supporting dynamic configuration via Helm values and enabling health check and metrics backends.
* Updated the Jaeger V2 config file to use new service endpoints, support health checks, and set the query base path and UI config file location. [[1]](diffhunk://#diff-84f4e3b8661556bb2e7bfd2c2d89d713be0ccde5745b4cb55ec95c1a397c5af2R9-R35) [[2]](diffhunk://#diff-84f4e3b8661556bb2e7bfd2c2d89d713be0ccde5745b4cb55ec95c1a397c5af2L45-R52)

**Service and deployment improvements:**

* Refactored the Jaeger Kubernetes deployment to use configurable replica counts, new container ports for Jaeger V2, and added liveness/readiness probes on the health endpoint.
* Updated Jaeger and plugin Kubernetes services to include the namespace and expose the new Jaeger V2 ports for OTLP and health checks. [[1]](diffhunk://#diff-db5e25564344220caa4eac0e82ed048099a18c9bd9238686b43cf8f4b026db91L4-R24) [[2]](diffhunk://#diff-4f9d00bab0198120fd3b9f0793b965d90ed8c3eb6cf274634066b2b03c766fb7R4)